### PR TITLE
Stack overflow error when using LocalDate

### DIFF
--- a/config/webpack.config-base.js
+++ b/config/webpack.config-base.js
@@ -37,6 +37,7 @@ const webConfig = {
         path: path.resolve(__dirname, '../dist/web'),
         libraryTarget: 'umd'
     },
+    externals: ["js-joda"]
 };
 
 module.exports = [


### PR DESCRIPTION
**Problem:**

Attempting to format `LocalTime` instance obtained from a DICOM file with js-joda `DateTimeFormatter` results in a stack overflow error:

```js
import { DateTimeFormatter } from "js-joda"

const time = elements.timeByTag(Tag.StudyTime)
time.format(DateTimeFormatter.ofPattern('HH:mm'))
```


```
      RangeError: Maximum call stack size exceeded                                                                                                                                              
          at <Jasmine>                                                                                                                                                                          
          at ZonedDateTime.getLong (http://localhost:9876/_karma_webpack_/node_modules/js-joda/dist/js-joda.esm.js:8047:1)                                                                      
          at ChronoField.getFrom (http://localhost:9876/_karma_webpack_/node_modules/@exini/dicom-streams-js/web/index.js:8709:1)                                                               
          at ZonedDateTime.getLong (http://localhost:9876/_karma_webpack_/node_modules/js-joda/dist/js-joda.esm.js:8058:1)                                                                      
          at ChronoField.getFrom (http://localhost:9876/_karma_webpack_/node_modules/@exini/dicom-streams-js/web/index.js:8709:1)                                                               
          at ZonedDateTime.getLong (http://localhost:9876/_karma_webpack_/node_modules/js-joda/dist/js-joda.esm.js:8058:1)                                                                      
          at ChronoField.getFrom (http://localhost:9876/_karma_webpack_/node_modules/@exini/dicom-streams-js/web/index.js:8709:1)                                                               
          at ZonedDateTime.getLong (http://localhost:9876/_karma_webpack_/node_modules/js-joda/dist/js-joda.esm.js:8058:1)                                                                      
          at ChronoField.getFrom (http://localhost:9876/_karma_webpack_/node_modules/@exini/dicom-streams-js/web/index.js:8709:1)                                                               
          at ZonedDateTime.getLong (http://localhost:9876/_karma_webpack_/node_modules/js-joda/dist/js-joda.esm.js:8058:1)                                                                      
          at ChronoField.getFrom (http://localhost:9876/_karma_webpack_/node_modules/@exini/dicom-streams-js/web/index.js:8709:1)                                                               
```

**Cause:**

dicom-streams-js bundles its own copy of js-joda package. The time instances returned from dicom-streams-js functions are constructed using that copy. These instances don't recognize js-joda objects that are loaded by the consumer of dicom-streams-js (like `DateTimeFormatter`). Effectively, two copies of js-joda are loaded, and they are not interoperable.

**Solution:**

Don't include a copy of `js-joda` in the bundle. The consumer of dicom-streams-js should be responsible for installing it. This should happen automatically since `js-joda` is declared as a dependency in `package.json`