### PR TITLE
Fix ideographic and phonetic name components parsing

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -2,4 +2,5 @@ module.exports = {
     require: ['ts-node/register/transpile-only', 'source-map-support/register'],
     recursive: true,
     spec: ['test/*-test.ts'],
+    watchFiles: ['src/**/*.ts', 'test/**/*.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "clean": "shx rm -rf build dist coverage",
         "lint": "eslint '*/**/*.ts' --quiet --fix",
         "test": "nyc mocha",
+        "test-watch": "nyc mocha --watch",
         "coverage": "nyc report --reporter=text-lcov | coveralls",
         "build-lib": "./node_modules/typescript/bin/tsc",
         "build-dev": "webpack --config config/webpack.config-dev.js",

--- a/src/person-name.ts
+++ b/src/person-name.ts
@@ -3,10 +3,6 @@ import { multiValueDelimiter, trim } from './base';
 
 export class ComponentGroup {
     constructor(public alphabetic: string, public ideographic: string = '', public phonetic: string = '') {}
-
-    toString(): string {
-        return (this.alphabetic + '=' + this.ideographic + '=' + this.phonetic).replace(/=+$/, '');
-    }
 }
 
 export class PersonName {
@@ -26,16 +22,16 @@ export class PersonName {
     }
 
     toString(): string {
-        return (
-            this.familyName +
-            '^' +
-            this.givenName +
-            '^' +
-            this.middleName +
-            '^' +
-            this.prefix +
-            '^' +
-            this.suffix
-        ).replace('/\\^+$/', '');
+        const components = [this.familyName, this.givenName, this.middleName, this.prefix, this.suffix];
+        const representations = ['alphabetic', 'ideographic', 'phonetic'] as const;
+        return representations
+            .map((repr) => {
+                return components
+                    .map((c) => c[repr])
+                    .join('^')
+                    .replace(/\^+$/, ''); // Trim trailing ^ separators
+            })
+            .join('=')
+            .replace(/=+$/, ''); // Trim trailing = separators
     }
 }

--- a/src/value.ts
+++ b/src/value.ts
@@ -674,10 +674,14 @@ export function parsePersonName(s: string): PersonName {
         return ss.concat(new Array(Math.max(0, n - ss.length)).fill(''));
     }
 
-    const comps = ensureLength(s.split(/\^/), 5)
-        .map((s1) => ensureLength(s1.split(/=/), 3).map(trim))
-        .map((c) => new ComponentGroup(c[0], c[1], c[2]));
+    function transpose(matrix: string[][]): string[][] {
+        return matrix[0].map((_, i) => matrix.map((col) => col[i]));
+    }
 
+    const matrix = ensureLength(s.split(/=/), 3)
+        .map(trim)
+        .map((s1) => ensureLength(s1.split(/\^/), 5));
+    const comps = transpose(matrix).map((c) => new ComponentGroup(c[0], c[1], c[2]));
     return new PersonName(comps[0], comps[1], comps[2], comps[3], comps[4]);
 }
 

--- a/test/value-test.ts
+++ b/test/value-test.ts
@@ -177,10 +177,10 @@ describe('Creating an element', () => {
         assert.deepStrictEqual(Value.fromPersonName(VR.PN, pn1).toPersonName(), pn1);
         assert.deepStrictEqual(Value.fromPersonNames(VR.PN, [pn1, pn2]).toPersonNames(), [pn1, pn2]);
 
-        assert.deepStrictEqual(Value.fromPersonName(VR.PN, pn1).toString(VR.PN), 'Doe^John^^^');
+        assert.deepStrictEqual(Value.fromPersonName(VR.PN, pn1).toString(VR.PN), 'Doe^John');
         assert.deepStrictEqual(
             Value.fromPersonName(VR.PN, pn2).toString(VR.PN),
-            'Doe=iDoe=pDoe^Jane=iJane=pJane^Middle=iMiddle=pMiddle^Prefix=iPrefix=pPrefix^Suffix=iSuffix=pSuffix',
+            'Doe^Jane^Middle^Prefix^Suffix=iDoe^iJane^iMiddle^iPrefix^iSuffix=pDoe^pJane^pMiddle^pPrefix^pSuffix',
         );
     });
 
@@ -470,6 +470,18 @@ describe('Parsing person names', () => {
             pn2,
             pn3,
         ]);
+    });
+
+    it('should parse person names with ideographic and phonetic components', () => {
+        // http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_H.3.html
+        const pn = new PersonName(
+            new ComponentGroup('Yamada', '山田', 'やまだ'),
+            new ComponentGroup('Tarou', '太郎', 'たろう'),
+        );
+        assert.deepStrictEqual(
+            Value.fromStrings(VR.PN, ['Yamada^Tarou=山田^太郎=やまだ^たろう']).toPersonNames(VR.PN),
+            [pn],
+        );
     });
 
     it('should trim whitespace', () => {


### PR DESCRIPTION
DICOM standard specifies three representations separated by `=`, and within each representation, five name components separated by `^` (e.g. `Yamada^Tarou=山田^太郎=やまだ^たろう`)

The previous parser was implemented the other way around - five name components, and within each component three possible representations.

Corresponding `dicom-streams` PR: https://github.com/exini/dicom-streams/pull/21

http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_H.3.html