### PR TITLE
Ensure files are not truncated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,33 +1,31 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: Node.js CI
 
-on:
-  workflow_dispatch:
-          
-  push:
-    branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
+on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+        include:
+          - node-version: 18.x
+            node-options: ""
+          - node-version: 20.x
+            node-options: ""
+          - node-version: 22.x
+            node-options: --no-experimental-strip-types
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci --lockfile-version=1
+      - run: npm test
+        env:
+          NODE_OPTIONS: ${{ matrix.node-options }}
+      - run: npm run build
+        env:
+          NODE_OPTIONS: ${{ matrix.node-options }}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -380,8 +380,8 @@ export class Parser {
             this.byteParser.startWith(new InAttribute(inDeflatedStep.state, inDeflatedStep.stop));
             const buff = inDeflatedStep.inflate();
             this.byteParser.parse(buff);
-            this.byteParser.isCompleted = true;
         }
+        this.byteParser.flush();
         return this.builder.build();
     }
 

--- a/test/parser-test.ts
+++ b/test/parser-test.ts
@@ -507,4 +507,23 @@ describe('DICOM parser', () => {
             .expectValueChunk()
             .expectDicomComplete();
     });
+
+    it('should handle truncated input', () => {
+        const bytes = concatv(
+            data.patientNameJohnDoe(),
+            data.pixelData(10),
+        );
+
+        const parser = new Parser();
+        parser.parse(bytes);
+        assert(parser.result().bytesByTag(Tag.PixelData)!.length === 10)
+        assert(parser.isComplete())
+
+        const truncatedBytes = bytes.subarray(0, bytes.length - 1);
+        const truncatedParser = new Parser();
+        truncatedParser.parse(truncatedBytes);
+        assert.throws(() => {
+            truncatedParser.result()
+        }, new Error('Parsing failed: 21 bytes remain after finished parsing'));
+    });
 });


### PR DESCRIPTION
DONE:
- Throw an error on truncated DICOM files
  - Flushing byte parser before getting the result ensures that entire input
has been parsed. 
  - If the file is truncated in the middle of a DICOM value, these bytes would not be parsed yet, and an error is thrown.